### PR TITLE
update scripts schema add payment_hash

### DIFF
--- a/migrations/2023-10-22-204308_scripts/up.sql
+++ b/migrations/2023-10-22-204308_scripts/up.sql
@@ -1,4 +1,3 @@
--- Your SQL goes here
 CREATE TABLE IF NOT EXISTS scripts (
     id                  BIGSERIAL   PRIMARY KEY,
     loop_out_id         BIGINT      REFERENCES loop_outs(id) ON DELETE CASCADE,
@@ -6,12 +5,13 @@ CREATE TABLE IF NOT EXISTS scripts (
     external_tapkey        TEXT        NOT NULL,
     internal_tapkey        TEXT        NOT NULL,
     internal_tapkey_tweak  TEXT        NOT NULL,
+    payment_hash        TEXT        NOT NULL,
     tree                TEXT[]      NOT NULL,
     cltv_expiry         INT         NOT NULL,
     remote_pubkey       TEXT        NOT NULL,
     local_pubkey        TEXT        NOT NULL,
     local_pubkey_index  INT         NOT NULL,
-    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(), 
     updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -390,6 +390,7 @@ pub(crate) mod tests {
             external_tapkey: "test-external-tapkey",
             internal_tapkey: "test-internal-tapkey",
             internal_tapkey_tweak: "test-internal-tapkey-tweak",
+            payment_hash: "test-payment-hash",
             tree: vec!["test-tree".to_string(), "test-tree2".to_string()],
             cltv_expiry: 100,
             remote_pubkey: "test-remote-pubkey".to_string(),

--- a/src/db.rs
+++ b/src/db.rs
@@ -446,6 +446,7 @@ pub(crate) mod tests {
         assert_eq!(ns.external_tapkey, ss.external_tapkey);
         assert_eq!(ns.internal_tapkey, ss.internal_tapkey);
         assert_eq!(ns.internal_tapkey_tweak, ss.internal_tapkey_tweak);
+        assert_eq!(ns.payment_hash, ss.payment_hash);
         assert_eq!(ns.cltv_expiry, ss.cltv_expiry);
         assert_eq!(ns.remote_pubkey, ss.remote_pubkey);
         assert_eq!(ns.local_pubkey, ss.local_pubkey);

--- a/src/lnd/client.rs
+++ b/src/lnd/client.rs
@@ -1,5 +1,4 @@
-use crate::settings;
-use crate::utils;
+use crate::{settings, utils};
 use hex;
 use std::collections::HashMap;
 
@@ -105,7 +104,7 @@ impl LNDGateway {
         let mut client = self.get_client().await;
 
         // TODO: do we have to generate this?
-        let (preimage, payment_hash) = LNDGateway::new_preimage();
+        let (preimage, payment_hash) = Self::new_preimage();
         let payment_addr = LNDGateway::new_payment_addr();
         // resolves lint vs compile error dilemma
         #[allow(deprecated)]
@@ -162,7 +161,7 @@ impl LNDGateway {
         cltv_timout: u64,
     ) -> Result<AddInvoiceResp, fedimint_tonic_lnd::Error> {
         let mut client = self.get_client().await;
-        let (preimage, payment_hash) = LNDGateway::new_preimage();
+        let (preimage, payment_hash) = Self::new_preimage();
 
         let req = invoicesrpc::AddHoldInvoiceRequest {
             memo: "looper swap out".to_string(),
@@ -276,15 +275,14 @@ impl LNDGateway {
         }
     }
 
-    pub fn new_preimage() -> ([u8; 32], [u8; 32]) {
+    fn new_preimage() -> ([u8; 32], [u8; 32]) {
         let preimage: [u8; 32] = utils::rand_32_bytes();
         let payment_hash = utils::sha256(&preimage);
 
         (preimage, payment_hash)
     }
 
-    // TODO move this to a general new_32_byte_array function
-    pub fn new_payment_addr() -> [u8; 32] {
+    fn new_payment_addr() -> [u8; 32] {
         utils::rand_32_bytes()
     }
 }

--- a/src/mempool/mod.rs
+++ b/src/mempool/mod.rs
@@ -133,10 +133,11 @@ pub(crate) mod tests {
             fee_estimate.half_hour_fee > 0
                 && fee_estimate.half_hour_fee <= fee_estimate.fastest_fee
         );
-        assert!(fee_estimate.hour_fee > 0 && fee_estimate.hour_fee <= fee_estimate.half_hour_fee);
-        assert!(fee_estimate.economy_fee > 0 && fee_estimate.economy_fee <= fee_estimate.hour_fee);
-        assert!(
-            fee_estimate.minimum_fee > 0 && fee_estimate.minimum_fee <= fee_estimate.economy_fee
-        );
+        assert!(fee_estimate.hour_fee > 0);
+        assert!(fee_estimate.hour_fee <= fee_estimate.half_hour_fee);
+        assert!(fee_estimate.economy_fee > 0);
+        assert!(fee_estimate.economy_fee <= fee_estimate.hour_fee);
+        assert!(fee_estimate.minimum_fee > 0);
+        assert!(fee_estimate.minimum_fee <= fee_estimate.economy_fee);
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -56,6 +56,7 @@ pub struct NewScript<'a> {
     pub external_tapkey: &'a str,
     pub internal_tapkey: &'a str,
     pub internal_tapkey_tweak: &'a str,
+    pub payment_hash: &'a str,
     pub tree: Vec<String>,
     pub cltv_expiry: i32,
     pub remote_pubkey: String,
@@ -74,6 +75,7 @@ pub struct Script {
     pub internal_tapkey: String,
     pub internal_tapkey_tweak: String,
     // TODO: replace tree with payment_hash
+    pub payment_hash: String,
     pub tree: Vec<Option<String>>,
     pub cltv_expiry: i32,
     pub remote_pubkey: String,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -31,6 +31,7 @@ diesel::table! {
         external_tapkey -> Text,
         internal_tapkey -> Text,
         internal_tapkey_tweak -> Text,
+        payment_hash -> Text,
         tree -> Array<Nullable<Text>>,
         cltv_expiry -> Int4,
         remote_pubkey -> Text,
@@ -57,4 +58,4 @@ diesel::joinable!(invoices -> loop_outs (loop_out_id));
 diesel::joinable!(scripts -> loop_outs (loop_out_id));
 diesel::joinable!(utxos -> scripts (script_id));
 
-diesel::allow_tables_to_appear_in_same_query!(invoices, loop_outs, scripts, utxos);
+diesel::allow_tables_to_appear_in_same_query!(invoices, loop_outs, scripts, utxos,);

--- a/src/services/loop_out.rs
+++ b/src/services/loop_out.rs
@@ -267,6 +267,7 @@ impl LoopOutService {
             external_tapkey: &tr.output_key().to_string(),
             internal_tapkey: &tr.internal_key().to_string(),
             internal_tapkey_tweak: &hex::encode(tweak.secret_bytes()),
+            payment_hash,
             tree: tree_to_vec(&tr),
             cltv_expiry: cltv_expiry_u32,
             remote_pubkey: buyer_pubkey.to_string(),


### PR DESCRIPTION
this diff changes the Diesel Schema without a new migration, so you will have to drop your `looper` database and recreate it and then run `diesel migration run` with the postgres URL in your env. 